### PR TITLE
Fixed static constructors being included in generation methods

### DIFF
--- a/src/Ninject.Extension.AutoFactories.Tests/GeneratorTests.cs
+++ b/src/Ninject.Extension.AutoFactories.Tests/GeneratorTests.cs
@@ -1,0 +1,38 @@
+﻿using Xunit.Abstractions;
+
+namespace Ninject.AutoFactories
+{
+    public class GeneratorTests : SnapshotTest
+    {
+        public GeneratorTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        { }
+
+        /// <summary>
+        /// Validates that types with static constructors are generated correctly
+        /// <see cref="https://github.com/ByronMayne/Ninject.Extensions.AutoFactories/issues/21"/>
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public Task StaticConstructor()
+        {
+            return Compose(
+                        testSubject: "Foo.BarFactory.g.cs",
+                        source: """
+                using Ninject;
+
+                namespace Foo
+                {
+                    [GenerateFactory]
+                    public class Bar
+                    {
+                        public Bar(string parameter)
+                        {}
+
+                        static Bar()
+                        {}
+                    }
+                }
+                """);
+        }
+    }
+}

--- a/src/Ninject.Extension.AutoFactories.Tests/SnapshotTest.cs
+++ b/src/Ninject.Extension.AutoFactories.Tests/SnapshotTest.cs
@@ -48,8 +48,16 @@ namespace Ninject.AutoFactories
         /// <param name="source">The source to try to run the source generator on</param>
         /// <returns>A task to await on</returns>
         protected async Task Compose(
-            string? source = "")
+            string? source = "",
+            string? testSubject = null)
         {
+            Assert.NotNull(source);
+
+            if (!string.IsNullOrWhiteSpace(testSubject))
+            {
+                m_testSubjects.Add(testSubject);
+            }
+
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
 
             IEnumerable<PortableExecutableReference> references = new[]

--- a/src/Ninject.Extension.AutoFactories.Tests/Snapshots/GeneratorTests.StaticConstructor#Foo.BarFactory.g.verified.cs
+++ b/src/Ninject.Extension.AutoFactories.Tests/Snapshots/GeneratorTests.StaticConstructor#Foo.BarFactory.g.verified.cs
@@ -1,0 +1,44 @@
+﻿//HintName: Foo.BarFactory.g.cs
+#nullable enable
+using System;
+using Ninject;
+using Ninject.Syntax;
+using Ninject.Parameters;
+
+namespace Foo
+{
+    public interface IBarFactory 
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="Foo.Bar"/>
+        /// </summary>
+        global::Foo.Bar Create(string parameter);
+    }
+}
+
+namespace Foo
+{
+
+    internal sealed partial class BarFactory : global::Foo.IBarFactory 
+    {
+        private readonly global::Ninject.Syntax.IResolutionRoot m_resolutionRoot;
+
+        public BarFactory(global::Ninject.Syntax.IResolutionRoot resolutionRoot)
+        {
+            m_resolutionRoot = resolutionRoot;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="Foo.Bar"/>
+        /// </summary>
+        public global::Foo.Bar Create(string parameter)
+        {
+            IParameter[] parameters = new IParameter[]
+            {
+                new ConstructorArgument("parameter", parameter)
+            };
+            global::Foo.Bar instance = m_resolutionRoot.Get<global::Foo.Bar>(parameters);
+            return instance;
+        }
+    }
+}

--- a/src/Ninject.Extension.AutoFactories/Mapping/ProductMapper.cs
+++ b/src/Ninject.Extension.AutoFactories/Mapping/ProductMapper.cs
@@ -75,10 +75,16 @@ namespace Ninject.AutoFactories.Mapping
 
             destination.FactoryType = new MetadataTypeName(fullyQualifedFactoryName);
 
+            IEnumerable<ConstructorDeclarationSyntax> constructors = classDeclaration.DescendantNodes()
+                .OfType<ConstructorDeclarationSyntax>()
+                // Fix for: https://github.com/ByronMayne/Ninject.Extensions.AutoFactories/issues/21
+                .Where(c => !c.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword)))
+                .ToList();
+
 
             destination.FactoryInterfaceType = new MetadataTypeName($"{destination.FactoryType.Namespace}.I{destination.FactoryType.TypeName}");
             destination.ProductType = new MetadataTypeName($"{@namespace}.{classDeclaration.Identifier.Text}");
-            destination.Constructors = m_constructureMapper.MapList(classDeclaration.DescendantNodes().OfType<ConstructorDeclarationSyntax>());
+            destination.Constructors = m_constructureMapper.MapList(constructors);
 
             if (destination.Constructors.Count == 0)
             {

--- a/src/Ninject.Extension.AutoFactories/Templates/FactoryTemplate.cs
+++ b/src/Ninject.Extension.AutoFactories/Templates/FactoryTemplate.cs
@@ -96,7 +96,8 @@ namespace Ninject.AutoFactories.Templates
                 if (isInterface)
                 {
                     writer.Write(";");
-                    return;
+                    writer.WriteNewLine();
+                    continue;
                 }
                 writer.WriteNewLine();
 
@@ -132,7 +133,7 @@ namespace Ninject.AutoFactories.Templates
 
         private void WriteParameter(ClassWriter writer, ParameterModel parameter)
         {
-            writer.Write($"global::{parameter.Type} {parameter.Name}");
+            writer.Write($"{parameter.Type} {parameter.Name}");
         }
     }
 


### PR DESCRIPTION
Fixed static constructors being include in generation causing an invalid contract to be created. 